### PR TITLE
Fix to work with ImGui 1.67

### DIFF
--- a/generate_imgui_bindings.pl
+++ b/generate_imgui_bindings.pl
@@ -2,6 +2,7 @@
 use strict;
 use warnings;
 use diagnostics;
+
 # This works for IMGUI 1.60 and does not get all functions
 #
 # to use ./generate_imgui_bindings.pl <../imgui/imgui.h >imgui_iterator.inl
@@ -146,6 +147,7 @@ sub generateImguiGeneric {
   my %funcNames;
   my %endTypeToInt;
   my @endTypes;
+  my @functionsAlreadyAdded;
   foreach $line (split /\n/, $imguiCodeBlock) {
     #replace ImVec2(x, y) with ImVec2 x, y so it's easier for regex (and ImVec4)
     $line =~ s/ImVec2\(([^,]*),([^\)]*)\)/ImVec2 $1 $2/g;
@@ -166,6 +168,13 @@ sub generateImguiGeneric {
       my @after;
       # real c++ function name
       my $funcName = $5;
+
+	  #say STDERR "Parsing function: " . $funcName;
+	  if (grep(/^$funcName$/, @functionsAlreadyAdded)) {
+		  #say STDERR $funcName;
+	  }
+	  push @functionsAlreadyAdded, $funcName;
+	  
       if (defined($bannedNames{$funcName})) {
         print "//Not allowed to use this function\n";
         $shouldPrint = 0;
@@ -335,6 +344,7 @@ sub generateImguiGeneric {
         }
         $funcNames{$luaFunc} = 1;
 
+		
         print "IMGUI_FUNCTION${functionSuffix}($luaFunc)\n";
         for (my $i = 0; $i < @before; $i++) {
           print $before[$i] . "\n";
@@ -445,9 +455,17 @@ my ($blocksref, $blocknamesref) = parse_blocks();
 my @blocks = @$blocksref;
 my @blocknames = @$blocknamesref;
 
+# @spaderthomas 3/1/2020: ImGui also puts its deprecated functions in namespace ImGui,
+# so we'll end up parsing a couple functions twice and causing compiler errors.
+#
+# This flag just means that we've parsed the main one, so don't parse the next one. If ImGui
+# splits up its header to multiple instances of namespace ImGui, this would break.
+my $alreadyParsedMainImguiNamespace = 0;
+
 for (my $i=0; $i < scalar @blocks; $i++) {
   print "//" . $blocknames[$i] . "\n";
-  if ($blocknames[$i] eq "namespace ImGui\n") {
+  if (($blocknames[$i] eq "namespace ImGui\n") and not $alreadyParsedMainImguiNamespace) {
+	$alreadyParsedMainImguiNamespace = 1;
     generateNamespaceImgui($blocks[$i]);
   }
   if ($blocknames[$i] =~ m/enum ImGui(.*)_\n/) {

--- a/parse_blocks.pl
+++ b/parse_blocks.pl
@@ -27,30 +27,57 @@
 # TODO FIX THIS ^
 
 #returns list of string blocks from stdin
+
+
+sub does_line_match_end_block {
+  my $line = shift;
+
+  # Make sure you take into account random whitespace that could happen by using [ ]*[\t]*
+  my $match = 0;
+  $match |= $line =~ m/^};[ ]*[\t]*\/\//;  # Semicolon,    comment
+  $match |= $line =~ m/^};[ ]*[\t]*$/;     # Semicolon,    no comment
+  $match |= $line =~ m/^}[ ]*[\t]*\/\//;   # No semicolon, comment
+  $match |= $line =~ m/^}[ ]*[\t]*$/;      # No semicolon, no comment
+  return $match;
+}
+
+sub does_line_match_begin_block {
+  my $line = shift;
+
+  my $match = 0;
+  $match |= $line =~ m/^{[ ]*[\t]*$/;
+  return $match
+}
+
 sub parse_blocks {
   my @blocks;
   my @blocknames;
   my $lastline;
   my $curBlock;
   while (my $line = <STDIN>) {
-   #This is a crappy way of parsing that works for
-   # imgui
-   if ($line =~ m/^{$/) {
-     push @blocknames, $lastline;
-     $curBlock = "";
-     next;
-   }
-   if ($line =~ m/^};$|^} \/\/|^}$/) {
-     push @blocks, $curBlock;
-     $curBlock = "";
-     next;
-   }
+	if (does_line_match_begin_block($line)) {
+		push @blocknames, $lastline;
+		$curBlock = "";
+		next;
+	}
+	  
+	if (does_line_match_end_block($line)) {
+	  push @blocks, $curBlock;
 
-   $curBlock .= $line . "\n";
-   $lastline = $line;
-  }
-  if (scalar @blocks != scalar @blocknames) {
-    print STDERR "WARNING PARSE BLOCKS IS RETURNING INVALID DATA\n"
+	  # Enforce the invariant that we should have the same number of elements in blocks / block names
+	  if (scalar @blocks != scalar @blocknames) {
+	  	print STDERR "The parser did a bad and has mismatched block open / close.";
+	  	print STDERR "This is probably a problem with the regular expression that matches block open and close.";
+	  	die
+	  }
+	    
+	  $curBlock = "";
+	    
+	  next;
+	}
+	
+	$curBlock .= $line . "\n";
+	$lastline = $line;
   }
   return (\@blocks, \@blocknames);
 }


### PR DESCRIPTION
Don't generate bindings for deprecated functions. A couple functions were declared both there and in the main namespace, which was causing a collision on macro expansion.

Fix block parsing to take into account whitespace.

Tested this with ImGui 1.67 WIP and it worked like a charm. I do not know if it works for newer versions.